### PR TITLE
feat: add tool filtering via regex patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ https://github.com/user-attachments/assets/8f551082-6982-4513-8fe7-b0f111be982d
 
 - 📋 **Comprehensive API Coverage**: Supports all functions available in Redmine's REST API
 - 🔒 **Read-Only Mode**: Supports safe data reference mode
+- 🔧 **Tool Filtering**: Control which tools are available using regex patterns
 
 ## Prerequisites
 
@@ -49,6 +50,13 @@ The following environment variables are required (specified in MCP client config
 - **REDMINE_MCP_READ_ONLY** (Optional): Enable read-only mode
   - `true`: Read-only mode (disables data modification operations)
   - `false` or unset: Allow all operations (default)
+- **REDMINE_MCP_TOOLS_ALLOW_PATTERN** (Optional): Regex pattern to allow only matching tools
+  - Example: `^get` (enable only tools starting with "get")
+  - If unset, all tools are allowed (subject to other settings)
+- **REDMINE_MCP_TOOLS_DENY_PATTERN** (Optional): Regex pattern to disable matching tools
+  - Example: `^delete` (disable all tools starting with "delete")
+  - If unset, no tools are denied (subject to other settings)
+  - Deny pattern takes priority over allow pattern
 
 ### MCP Client Configuration
 
@@ -205,6 +213,60 @@ This MCP server comprehensively supports the functions provided by [Redmine's RE
 ### Read-Only Mode
 
 By setting `REDMINE_MCP_READ_ONLY=true`, you can disable data modification operations. This allows safe data reference.
+
+### Tool Filtering
+
+You can control which tools are available using the following environment variables:
+
+- **`REDMINE_MCP_TOOLS_ALLOW_PATTERN`**: Only tools whose names match this regex are enabled.
+  - Example: `^get` enables only read-oriented tools like `getIssues`, `getProjects`, etc.
+- **`REDMINE_MCP_TOOLS_DENY_PATTERN`**: Tools whose names match this regex are disabled.
+  - Example: `^delete` disables all delete operations.
+
+When both are set, deny takes priority. These can also be combined with `REDMINE_MCP_READ_ONLY`.
+
+**Example: Allow only issue-related tools**
+```json
+"env": {
+  "REDMINE_MCP_TOOLS_ALLOW_PATTERN": "Issue"
+}
+```
+
+**Example: Disable all delete and archive operations**
+```json
+"env": {
+  "REDMINE_MCP_TOOLS_DENY_PATTERN": "^(delete|archive)"
+}
+```
+
+### Available Tools
+
+The following tools are available (based on [Redmine REST API](https://www.redmine.org/projects/redmine/wiki/rest_api) categories):
+
+| Category | Tools |
+|---|---|
+| Issues | getIssues, getIssue, createIssue, updateIssue, deleteIssue, addWatcher, removeWatcher, addRelatedIssue, removeRelatedIssue |
+| Projects | getProjects, getProject, createProject, updateProject, deleteProject, archiveProject, unarchiveProject, closeProject, reopenProject |
+| Project Memberships | getMemberships, getMembership, createMembership, updateMembership, deleteMembership |
+| Users | getUsers, getUser, createUser, updateUser, deleteUser, getCurrentUser |
+| Time Entries | getTimeEntries, getTimeEntry, createTimeEntry, updateTimeEntry, deleteTimeEntry |
+| News | getNewsList, getNewsListByProject, getNews, createNews, updateNews, deleteNews |
+| Issue Relations | getIssueRelations, getIssueRelation, createIssueRelation, deleteIssueRelation |
+| Versions | getVersionsByProject, getVersions, createVersion, updateVersion, deleteVersion |
+| Wiki Pages | getWikiPages, getWikiPage, getWikiPageByVersion, updateWikiPage, deleteWikiPage |
+| Queries | getQueries |
+| Attachments | getAttachment, updateAttachment, deleteAttachment, uploadAttachmentFromLocalFile, uploadAttachmentFromBase64Content, downloadAttachmentToLocalFile, downloadAttachmentAsBase64Content, downloadThumbnailToLocalFile, downloadThumbnailAsBase64Content |
+| Issue Statuses | getIssueStatuses |
+| Trackers | getTrackers |
+| Enumerations | getIssuePriorities, getTimeEntryActivities, getDocumentCategories |
+| Issue Categories | getIssueCategories, getIssueCategory, createIssueCategory, updateIssueCategory, deleteIssueCategory |
+| Roles | getRoles, getRole |
+| Groups | getGroups, getGroup, createGroup, updateGroup, deleteGroup, addUserToGroup, removeUserFromGroup |
+| Custom Fields | getCustomFields |
+| Search | search |
+| Files | getFiles, createFile |
+| My Account | getMyAccount, updateMyAccount |
+| Journals | updateJournal |
 
 ## License
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,23 @@ export interface ServerConfig {
   readOnlyMode: boolean;
   redmineUrl: string;
   redmineApiKey: string;
+  toolsAllowPattern: RegExp | null;
+  toolsDenyPattern: RegExp | null;
 }
+
+const compilePattern = (
+  value: string | undefined,
+  varName: string,
+): RegExp | null => {
+  if (!value) return null;
+  try {
+    return new RegExp(value);
+  } catch (e) {
+    throw new Error(
+      `Invalid regex in ${varName}: "${value}" - ${(e as Error).message}`,
+    );
+  }
+};
 
 /**
  * Load configuration from environment variables
@@ -24,10 +40,21 @@ const loadConfig = (): ServerConfig => {
     throw new Error("REDMINE_API_KEY environment variable is not set");
   }
 
+  const toolsAllowPattern = compilePattern(
+    process.env.REDMINE_MCP_TOOLS_ALLOW_PATTERN,
+    "REDMINE_MCP_TOOLS_ALLOW_PATTERN",
+  );
+  const toolsDenyPattern = compilePattern(
+    process.env.REDMINE_MCP_TOOLS_DENY_PATTERN,
+    "REDMINE_MCP_TOOLS_DENY_PATTERN",
+  );
+
   return {
     readOnlyMode,
     redmineUrl,
     redmineApiKey,
+    toolsAllowPattern,
+    toolsDenyPattern,
   };
 };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -268,11 +268,20 @@ const server = new McpServer({
   version: packageJson.version,
 });
 
-// Track registered tools for statistics
-const registeredTools = new Map<string, ToolType>();
+// Track all tools for statistics
+const allTools = new Map<string, ToolType>();
+
+const isToolEnabled = (toolName: string, toolType: ToolType): boolean => {
+  if (config.readOnlyMode && toolType === ToolType.WRITE) return false;
+  if (config.toolsDenyPattern && config.toolsDenyPattern.test(toolName))
+    return false;
+  if (config.toolsAllowPattern && !config.toolsAllowPattern.test(toolName))
+    return false;
+  return true;
+};
 
 /**
- * Helper function to conditionally register tools based on read-only mode
+ * Helper function to conditionally register tools based on configuration
  */
 const registerTool = <Args extends ZodRawShape>(
   toolName: string,
@@ -282,10 +291,9 @@ const registerTool = <Args extends ZodRawShape>(
   handler: ToolCallback<Args>
 ) => {
   // Track tool registration for statistics
-  registeredTools.set(toolName, toolType);
+  allTools.set(toolName, toolType);
 
-  if (config.readOnlyMode && toolType === ToolType.WRITE) {
-    // Skip registration of write tools in read-only mode
+  if (!isToolEnabled(toolName, toolType)) {
     return;
   }
   server.tool(toolName, description, schemas, handler);
@@ -293,20 +301,25 @@ const registerTool = <Args extends ZodRawShape>(
 
 // Log server mode after all tools are registered
 const logServerMode = () => {
-  const readOnlyCount = Array.from(registeredTools.values()).filter(
-    (t) => t === ToolType.READ_ONLY
+  const toolEntries = Array.from(allTools.entries());
+  const enabledCount = toolEntries.filter(([name, type]) =>
+    isToolEnabled(name, type)
   ).length;
-  const writeCount = Array.from(registeredTools.values()).filter(
-    (t) => t === ToolType.WRITE
-  ).length;
+  const disabledCount = toolEntries.length - enabledCount;
 
+  console.error("Starting Redmine MCP Server");
   if (config.readOnlyMode) {
-    console.error("Starting Redmine MCP Server in READ-ONLY mode");
-    console.error(`Available tools: ${readOnlyCount} read-only operations`);
-    console.error(`Disabled tools: ${writeCount} write operations`);
-  } else {
-    console.error("Starting Redmine MCP Server in FULL mode");
-    console.error(`Available tools: ${readOnlyCount + writeCount} operations`);
+    console.error("  - Read-only mode: write operations disabled");
+  }
+  if (config.toolsAllowPattern) {
+    console.error(`  - Allow pattern: ${config.toolsAllowPattern.source}`);
+  }
+  if (config.toolsDenyPattern) {
+    console.error(`  - Deny pattern: ${config.toolsDenyPattern.source}`);
+  }
+  console.error(`Available tools: ${enabledCount} operations`);
+  if (disabledCount > 0) {
+    console.error(`Disabled tools: ${disabledCount} operations`);
   }
 };
 


### PR DESCRIPTION
Add REDMINE_MCP_TOOLS_ALLOW_PATTERN and REDMINE_MCP_TOOLS_DENY_PATTERN environment variables to enable fine-grained control over which tools are registered. Deny takes priority over allow, and both can be combined with the existing REDMINE_MCP_READ_ONLY setting.