### PR TITLE
fix: handle cli metadata flags before config validation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,45 @@
+export type CliResult =
+  | { handled: true; exitCode: number }
+  | { handled: false };
+
+export function handleCliMetadataFlags(
+  argv: string[],
+  version: string,
+  out: Pick<NodeJS.WriteStream, "write"> = process.stdout,
+  err: Pick<NodeJS.WriteStream, "write"> = process.stderr,
+): CliResult {
+  const args = argv.slice(2);
+
+  if (args.length === 0) {
+    return { handled: false };
+  }
+
+  if (args.includes("--help") || args.includes("-h")) {
+    out.write(getHelpText());
+    return { handled: true, exitCode: 0 };
+  }
+
+  if (args.includes("--version") || args.includes("-v")) {
+    out.write(`${version}\n`);
+    return { handled: true, exitCode: 0 };
+  }
+
+  const unknownOption = args.find((arg) => arg.startsWith("-"));
+  if (unknownOption) {
+    err.write(`Unknown option: ${unknownOption}\n\n${getHelpText()}`);
+    return { handled: true, exitCode: 1 };
+  }
+
+  return { handled: false };
+}
+
+function getHelpText(): string {
+  return `Usage: redmine-mcp-server [options]
+
+Redmine MCP server over stdio.
+
+Options:
+  -h, --help       Display help for command
+  -v, --version    Display package version
+`;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,7 +58,18 @@ const loadConfig = (): ServerConfig => {
   };
 };
 
+let cachedConfig: ServerConfig | null = null;
+
 /**
  * Get current configuration
  */
-export const config = loadConfig();
+export const getConfig = (): ServerConfig => {
+  cachedConfig ??= loadConfig();
+  return cachedConfig;
+};
+
+export const config: ServerConfig = new Proxy({} as ServerConfig, {
+  get(_target, property: keyof ServerConfig) {
+    return getConfig()[property];
+  },
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,8 +10,14 @@ import {
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import packageJson from "../package.json" assert { type: "json" };
+import { handleCliMetadataFlags } from "./cli.js";
 
 import { config } from "./config.js";
+
+const cliResult = handleCliMetadataFlags(process.argv, packageJson.version);
+if (cliResult.handled) {
+  process.exit(cliResult.exitCode);
+}
 
 // Tool classification enum
 enum ToolType {


### PR DESCRIPTION
## Summary

- handle top-level `--help` / `-h` and `--version` / `-v` before Redmine config validation
- return a concise error for unknown top-level options without requiring `REDMINE_URL` / `REDMINE_API_KEY`
- make config loading lazy so importing the CLI entry no longer validates environment variables before metadata flags can be handled

## Reproduction before this change

With `@onozaty/redmine-mcp-server@1.2.0` installed and no Redmine env vars set:

```powershell
redmine-mcp-server --help
redmine-mcp-server --version
```

Both commands exited 1 with `REDMINE_URL environment variable is not set` instead of showing CLI metadata.

## Verification

```powershell
corepack pnpm install --frozen-lockfile --ignore-scripts
# Windows equivalent of the current `pnpm gen` script, because `rm -rf` is not available in PowerShell:
Remove-Item -Recurse -Force src\__generated__ -ErrorAction SilentlyContinue
corepack pnpm exec orval
node post-generate.js
corepack pnpm exec tsdown
node dist\server.mjs --help
node dist\server.mjs --version
node dist\server.mjs --definitely-not-real
node dist\server.mjs
git diff --check
```

Results:

- dependency install passed
- `orval` + `post-generate.js` passed
- `tsdown` build passed
- `--help` exits 0 and prints usage without Redmine env vars
- `--version` exits 0 and prints `1.2.0` without Redmine env vars
- unknown top-level option exits 1 with a concise message
- normal no-arg startup still exits 1 with the missing `REDMINE_URL` guidance
- `git diff --check` passed

Note: `corepack pnpm exec tsc --noEmit` currently reports an existing generated-code type error (`UploadAttachmentFileBody` is not exported from `src/__generated__/http-schemas`) after running the generator. That appears unrelated to this CLI metadata fix; the project build path uses `tsdown`, which passed.