### PR TITLE
feat: add RedmineUP CRM tools (contacts, deals, notes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ This MCP server comprehensively supports the functions provided by [Redmine's RE
 - **Files**: Upload and download files
 - **Attachments**: Upload, download files, and get thumbnails
 - **Queries**: Execute saved queries
+- **CRM (RedmineUP plugin)**: Manage contacts, deals, and notes (requires the third-party RedmineUP CRM plugin)
 - **Custom Fields**: Get and manage custom fields
 - **Roles**: Get and manage roles
 - **Trackers**: Get and manage trackers
@@ -267,6 +268,10 @@ The following tools are available (based on [Redmine REST API](https://www.redmi
 | Files | getFiles, createFile |
 | My Account | getMyAccount, updateMyAccount |
 | Journals | updateJournal |
+| CRM (RedmineUP plugin) | getContacts, getContact, createContact, updateContact, deleteContact, getDeals, getDeal, createDeal, updateDeal, deleteDeal, createNote, getDealStatuses, getDealCategories, getContactTags |
+
+> [!NOTE]
+> The **CRM** tools require the third-party [RedmineUP CRM plugin](https://www.redmineup.com/pages/help/crm) to be installed on the Redmine instance. On instances without the plugin they will simply return errors. If you don't use the plugin, you can hide the whole group with `REDMINE_MCP_TOOLS_DENY_PATTERN` (e.g. `(Contact|Deal|Note)`); conversely you can expose only the CRM tools with `REDMINE_MCP_TOOLS_ALLOW_PATTERN`.
 
 ## License
 

--- a/redmine-openapi.yaml
+++ b/redmine-openapi.yaml
@@ -110,6 +110,10 @@ tags:
       url: https://www.redmine.org/projects/redmine/wiki/Rest_Journals?parent=Rest_api
   - name: Repositories
     description: Undocumented
+  - name: CRM
+    description: "RedmineUP CRM plugin (third-party). Requires the CRM plugin to be installed on the Redmine instance."
+    externalDocs:
+      url: https://www.redmineup.com/pages/help/crm
 externalDocs:
   description: Redmine API Official Developer Guide
   url: https://www.redmine.org/projects/redmine/wiki/Rest_api
@@ -3453,6 +3457,434 @@ paths:
       responses:
         "204":
           description: ""
+  /contacts.{format}:
+    get:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/listing-contacts-api
+      summary: List contacts
+      operationId: getContacts
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/offset"
+        - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+        - name: project_id
+          in: query
+          schema:
+            type: string
+        - name: assigned_to_id
+          in: query
+          schema:
+            type: integer
+        - name: search
+          in: query
+          schema:
+            type: string
+        - name: tags
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - contacts
+                properties:
+                  contacts:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/crm_contact"
+                  total_count:
+                    type: integer
+                  offset:
+                    type: integer
+                  limit:
+                    type: integer
+    post:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/api-create-contact-related-with-issue
+      summary: Create contact
+      operationId: createContact
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - contact
+              properties:
+                contact:
+                  $ref: "#/components/schemas/crm_contact_write"
+      responses:
+        "201":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contact:
+                    $ref: "#/components/schemas/crm_contact"
+  /contacts/{contactId}.{format}:
+    get:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/listing-contacts-api
+      summary: Show contact
+      operationId: getContact
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/contact_id"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+        - name: include
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - notes
+                - contacts
+                - deals
+                - tickets
+          explode: false
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - contact
+                properties:
+                  contact:
+                    $ref: "#/components/schemas/crm_contact"
+    put:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/listing-contacts-api
+      summary: Update contact
+      operationId: updateContact
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/contact_id"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - contact
+              properties:
+                contact:
+                  $ref: "#/components/schemas/crm_contact_write"
+      responses:
+        "204":
+          description: ""
+    delete:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/listing-contacts-api
+      summary: Delete contact
+      operationId: deleteContact
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/contact_id"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+      responses:
+        "204":
+          description: ""
+  /deals.{format}:
+    get:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/rest-api-deals
+      summary: List deals
+      operationId: getDeals
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/offset"
+        - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+        - name: project_id
+          in: query
+          schema:
+            type: string
+        - name: contact_id
+          in: query
+          schema:
+            type: integer
+        - name: assigned_to_id
+          in: query
+          schema:
+            type: integer
+        - name: status_id
+          in: query
+          schema:
+            type: integer
+        - name: search
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - deals
+                properties:
+                  deals:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/crm_deal"
+                  total_count:
+                    type: integer
+                  offset:
+                    type: integer
+                  limit:
+                    type: integer
+    post:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/rest-api-deals
+      summary: Create deal
+      operationId: createDeal
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - deal
+              properties:
+                deal:
+                  $ref: "#/components/schemas/crm_deal_write"
+      responses:
+        "201":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deal:
+                    $ref: "#/components/schemas/crm_deal"
+  /deals/{dealId}.{format}:
+    get:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/rest-api-deals
+      summary: Show deal
+      operationId: getDeal
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/deal_id"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+        - name: include
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - notes
+          explode: false
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - deal
+                properties:
+                  deal:
+                    $ref: "#/components/schemas/crm_deal"
+    put:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/rest-api-deals
+      summary: Update deal
+      operationId: updateDeal
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/deal_id"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - deal
+              properties:
+                deal:
+                  $ref: "#/components/schemas/crm_deal_write"
+      responses:
+        "204":
+          description: ""
+    delete:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/rest-api-deals
+      summary: Delete deal
+      operationId: deleteDeal
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/deal_id"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+      responses:
+        "204":
+          description: ""
+  /notes.{format}:
+    post:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/api-create-note-for-contact-with-attachment
+      summary: Create note
+      operationId: createNote
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - source_id
+                - source_type
+                - note
+              properties:
+                project_id:
+                  type: string
+                source_id:
+                  type: integer
+                source_type:
+                  type: string
+                  enum:
+                    - Contact
+                    - Deal
+                note:
+                  type: object
+                  required:
+                    - content
+                  properties:
+                    content:
+                      type: string
+                    type_id:
+                      type: integer
+                      nullable: true
+                    note_time:
+                      type: string
+      responses:
+        "201":
+          description: ""
+  /deal_statuses.{format}:
+    get:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/rest-api-deal-statuses
+      summary: List deal statuses
+      operationId: getDealStatuses
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - deal_statuses
+                properties:
+                  deal_statuses:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/crm_deal_status"
+  /contact_tags.{format}:
+    get:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/rest-api-contact-tags
+      summary: List contact tags
+      operationId: getContactTags
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - tags
+                properties:
+                  tags:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/crm_contact_tag"
+  /projects/{projectId}/deal_categories.{format}:
+    get:
+      tags:
+        - CRM
+      externalDocs:
+        url: https://www.redmineup.com/pages/help/crm/rest-api-deal-categories
+      summary: List deal categories
+      operationId: getDealCategories
+      parameters:
+        - $ref: "#/components/parameters/format"
+        - $ref: "#/components/parameters/project_id"
+        - $ref: "#/components/parameters/x_redmine_switch_user"
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - deal_categories
+                properties:
+                  deal_categories:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/crm_deal_category"
 components:
   securitySchemes:
     BasicAuth:
@@ -3608,6 +4040,18 @@ components:
       required: true
       schema:
         type: string
+    contact_id:
+      name: contactId
+      in: path
+      required: true
+      schema:
+        type: integer
+    deal_id:
+      name: dealId
+      in: path
+      required: true
+      schema:
+        type: integer
   schemas:
     id_name:
       type: object
@@ -4968,3 +5412,253 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/custom_field_value"
+    crm_address:
+      type: object
+      properties:
+        street1:
+          type: string
+          nullable: true
+        street2:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        region:
+          type: string
+          nullable: true
+        postcode:
+          type: string
+          nullable: true
+        country_code:
+          type: string
+          nullable: true
+        country:
+          type: string
+          nullable: true
+    crm_contact:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+        first_name:
+          type: string
+        last_name:
+          type: string
+        middle_name:
+          type: string
+        company:
+          type: string
+        job_title:
+          type: string
+        phone:
+          type: string
+          nullable: true
+        email:
+          type: string
+          nullable: true
+        website:
+          type: string
+          nullable: true
+        skype_name:
+          type: string
+          nullable: true
+        birthday:
+          type: string
+          nullable: true
+        background:
+          type: string
+          nullable: true
+        is_company:
+          type: boolean
+        address:
+          $ref: "#/components/schemas/crm_address"
+        tags:
+          type: array
+          items:
+            type: string
+        assigned_to:
+          $ref: "#/components/schemas/id_name"
+        author:
+          $ref: "#/components/schemas/id_name"
+        visibility:
+          type: integer
+        custom_fields:
+          type: array
+          items:
+            $ref: "#/components/schemas/custom_field_value"
+        created_on:
+          type: string
+          format: date-time
+        updated_on:
+          type: string
+          format: date-time
+    crm_contact_write:
+      type: object
+      description: "Writable contact fields. On create, first_name and project_id are required by the CRM plugin; on update, only the fields to change need to be sent."
+      properties:
+        project_id:
+          type: string
+        first_name:
+          type: string
+        last_name:
+          type: string
+        middle_name:
+          type: string
+        company:
+          type: string
+        job_title:
+          type: string
+        phone:
+          type: string
+        email:
+          type: string
+        website:
+          type: string
+        skype_name:
+          type: string
+        birthday:
+          type: string
+          format: date
+        background:
+          type: string
+        is_company:
+          type: boolean
+        assigned_to_id:
+          type: integer
+        visibility:
+          type: integer
+          enum:
+            - 0
+            - 1
+            - 2
+        tag_list:
+          type: string
+        address_attributes:
+          $ref: "#/components/schemas/crm_address"
+        custom_fields:
+          $ref: "#/components/schemas/custom_fields"
+    crm_deal:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        price:
+          type: string
+          nullable: true
+        currency:
+          type: string
+          nullable: true
+        probability:
+          type: integer
+          nullable: true
+        due_date:
+          type: string
+          nullable: true
+        background:
+          type: string
+          nullable: true
+        price_type:
+          type: integer
+          nullable: true
+        duration:
+          type: integer
+          nullable: true
+        status:
+          $ref: "#/components/schemas/id_name"
+        category:
+          $ref: "#/components/schemas/id_name"
+        project:
+          $ref: "#/components/schemas/id_name"
+        contact:
+          $ref: "#/components/schemas/id_name"
+        assigned_to:
+          $ref: "#/components/schemas/id_name"
+        author:
+          $ref: "#/components/schemas/id_name"
+        custom_fields:
+          type: array
+          items:
+            $ref: "#/components/schemas/custom_field_value"
+        created_on:
+          type: string
+          format: date-time
+        updated_on:
+          type: string
+          format: date-time
+    crm_deal_write:
+      type: object
+      description: "Writable deal fields. On create, name and project_id are required by the CRM plugin; on update, only the fields to change need to be sent."
+      properties:
+        project_id:
+          type: string
+        name:
+          type: string
+        contact_id:
+          type: integer
+        price:
+          type: string
+        currency:
+          type: string
+        probability:
+          type: integer
+        due_date:
+          type: string
+          format: date
+        background:
+          type: string
+        status_id:
+          type: integer
+        category_id:
+          type: integer
+        assigned_to_id:
+          type: integer
+        custom_fields:
+          $ref: "#/components/schemas/custom_fields"
+    crm_deal_status:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        is_default:
+          type: boolean
+        status_type:
+          type: integer
+        color:
+          type: integer
+        position:
+          type: integer
+    crm_deal_category:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    crm_contact_tag:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        color:
+          type: integer
+          nullable: true

--- a/src/server.ts
+++ b/src/server.ts
@@ -107,6 +107,24 @@ import {
   updateWikiPageHandler,
 } from "./__generated__/handlers.js";
 
+// Import generated CRM handlers (RedmineUP CRM plugin)
+import {
+  createContactHandler,
+  createDealHandler,
+  createNoteHandler,
+  deleteContactHandler,
+  deleteDealHandler,
+  getContactHandler,
+  getContactsHandler,
+  getContactTagsHandler,
+  getDealCategoriesHandler,
+  getDealHandler,
+  getDealsHandler,
+  getDealStatusesHandler,
+  updateContactHandler,
+  updateDealHandler,
+} from "./__generated__/handlers.js";
+
 // Import generated schemas
 import {
   addRelatedIssueBody,
@@ -240,6 +258,33 @@ import {
   updateVersionParams,
   updateWikiPageBody,
   updateWikiPageParams,
+} from "./__generated__/tool-schemas.zod.js";
+
+// Import generated CRM schemas (RedmineUP CRM plugin)
+import {
+  createContactBody,
+  createContactParams,
+  createDealBody,
+  createDealParams,
+  createNoteBody,
+  createNoteParams,
+  deleteContactParams,
+  deleteDealParams,
+  getContactParams,
+  getContactQueryParams,
+  getContactsParams,
+  getContactsQueryParams,
+  getContactTagsParams,
+  getDealCategoriesParams,
+  getDealParams,
+  getDealQueryParams,
+  getDealsParams,
+  getDealsQueryParams,
+  getDealStatusesParams,
+  updateContactBody,
+  updateContactParams,
+  updateDealBody,
+  updateDealParams,
 } from "./__generated__/tool-schemas.zod.js";
 
 // Import custom attachment functionality
@@ -981,6 +1026,110 @@ registerTool(
   ToolType.READ_ONLY,
   { pathParams: downloadThumbnailAsBase64ContentParams },
   downloadThumbnailAsBase64ContentHandler
+);
+
+// Register RedmineUP CRM plugin tools
+// These require the third-party RedmineUP CRM plugin to be installed on the
+// Redmine instance. On instances without the plugin they simply return errors.
+// They can be filtered as a group via REDMINE_MCP_TOOLS_ALLOW_PATTERN /
+// REDMINE_MCP_TOOLS_DENY_PATTERN (e.g. "(Contact|Deal|Note)").
+registerTool(
+  "getContacts",
+  "List CRM contacts (RedmineUP CRM plugin)",
+  ToolType.READ_ONLY,
+  { pathParams: getContactsParams, queryParams: getContactsQueryParams },
+  getContactsHandler
+);
+registerTool(
+  "getContact",
+  "Show CRM contact (RedmineUP CRM plugin)",
+  ToolType.READ_ONLY,
+  { pathParams: getContactParams, queryParams: getContactQueryParams },
+  getContactHandler
+);
+registerTool(
+  "createContact",
+  "Create CRM contact (RedmineUP CRM plugin)",
+  ToolType.WRITE,
+  { pathParams: createContactParams, bodyParams: createContactBody },
+  createContactHandler
+);
+registerTool(
+  "updateContact",
+  "Update CRM contact (RedmineUP CRM plugin)",
+  ToolType.WRITE,
+  { pathParams: updateContactParams, bodyParams: updateContactBody },
+  updateContactHandler
+);
+registerTool(
+  "deleteContact",
+  "Delete CRM contact (RedmineUP CRM plugin)",
+  ToolType.WRITE,
+  { pathParams: deleteContactParams },
+  deleteContactHandler
+);
+registerTool(
+  "getDeals",
+  "List CRM deals (RedmineUP CRM plugin)",
+  ToolType.READ_ONLY,
+  { pathParams: getDealsParams, queryParams: getDealsQueryParams },
+  getDealsHandler
+);
+registerTool(
+  "getDeal",
+  "Show CRM deal (RedmineUP CRM plugin)",
+  ToolType.READ_ONLY,
+  { pathParams: getDealParams, queryParams: getDealQueryParams },
+  getDealHandler
+);
+registerTool(
+  "createDeal",
+  "Create CRM deal (RedmineUP CRM plugin)",
+  ToolType.WRITE,
+  { pathParams: createDealParams, bodyParams: createDealBody },
+  createDealHandler
+);
+registerTool(
+  "updateDeal",
+  "Update CRM deal (RedmineUP CRM plugin)",
+  ToolType.WRITE,
+  { pathParams: updateDealParams, bodyParams: updateDealBody },
+  updateDealHandler
+);
+registerTool(
+  "deleteDeal",
+  "Delete CRM deal (RedmineUP CRM plugin)",
+  ToolType.WRITE,
+  { pathParams: deleteDealParams },
+  deleteDealHandler
+);
+registerTool(
+  "createNote",
+  "Create a CRM note on a contact or deal (RedmineUP CRM plugin)",
+  ToolType.WRITE,
+  { pathParams: createNoteParams, bodyParams: createNoteBody },
+  createNoteHandler
+);
+registerTool(
+  "getDealStatuses",
+  "List CRM deal statuses (RedmineUP CRM plugin)",
+  ToolType.READ_ONLY,
+  { pathParams: getDealStatusesParams },
+  getDealStatusesHandler
+);
+registerTool(
+  "getDealCategories",
+  "List CRM deal categories for a project (RedmineUP CRM plugin)",
+  ToolType.READ_ONLY,
+  { pathParams: getDealCategoriesParams },
+  getDealCategoriesHandler
+);
+registerTool(
+  "getContactTags",
+  "List CRM contact tags (RedmineUP CRM plugin)",
+  ToolType.READ_ONLY,
+  { pathParams: getContactTagsParams },
+  getContactTagsHandler
 );
 
 


### PR DESCRIPTION
## Summary

Adds support for the [RedmineUP CRM plugin](https://www.redmineup.com/pages/help/crm) REST API, following the same OpenAPI-driven approach as the rest of the server. The endpoints are defined in `redmine-openapi.yaml`, so orval generates the handlers and Zod schemas, and they are registered in `src/server.ts` exactly like the core Redmine tools.

14 tools are added:

| Tool | Type | Endpoint |
|---|---|---|
| `getContacts` | read | `GET /contacts.json` |
| `getContact` | read | `GET /contacts/{id}.json` (`include`: notes, contacts, deals, tickets) |
| `createContact` | write | `POST /contacts.json` |
| `updateContact` | write | `PUT /contacts/{id}.json` |
| `deleteContact` | write | `DELETE /contacts/{id}.json` |
| `getDeals` | read | `GET /deals.json` |
| `getDeal` | read | `GET /deals/{id}.json` (`include`: notes) |
| `createDeal` | write | `POST /deals.json` |
| `updateDeal` | write | `PUT /deals/{id}.json` |
| `deleteDeal` | write | `DELETE /deals/{id}.json` |
| `createNote` | write | `POST /notes.json` (note on a contact or deal) |
| `getDealStatuses` | read | `GET /deal_statuses.json` |
| `getDealCategories` | read | `GET /projects/{projectId}/deal_categories.json` |
| `getContactTags` | read | `GET /contact_tags.json` |

Companies are represented by the CRM plugin as contacts with `is_company: true`, so they are covered by the contact tools rather than a separate resource. List endpoints use the standard `offset`/`limit` pagination plus the plugin's documented filters (`project_id`, `assigned_to_id`, `search`, `tags`, `status_id`, `contact_id`).

## Design notes

- **No new enable flag.** The CRM plugin is optional and third-party, but rather than introduce a dedicated `..._CRM_ENABLED` variable I kept things consistent with the existing filtering model: every tool is classified `READ_ONLY` / `WRITE`, so `REDMINE_MCP_READ_ONLY` already disables all CRM writes, and the whole group can be shown/hidden with `REDMINE_MCP_TOOLS_ALLOW_PATTERN` / `REDMINE_MCP_TOOLS_DENY_PATTERN` (e.g. `(Contact|Deal|Note)`). On instances without the plugin the tools simply return errors, the same way any unsupported endpoint would.
- Generated files under `src/__generated__/` are not committed (they are `.gitignore`d and produced by `pnpm gen`), so the diff is limited to the spec, the registrations, and the docs.
- README updated: new row in the tool table, a note about the plugin requirement, and a bullet in the feature list.

## Testing

- `pnpm build` (orval codegen + tsdown) succeeds.
- Smoke-tested the built server over stdio with the MCP SDK client:
  - default: all 14 CRM tools are listed;
  - `REDMINE_MCP_READ_ONLY=true`: only the 7 read tools remain (the 7 write tools are gated out);
  - `REDMINE_MCP_TOOLS_ALLOW_PATTERN=(Contact|Deal|Note)`: exactly the 14 CRM tools are exposed.

Endpoint shapes, query parameters, and `include` options were taken from the RedmineUP CRM REST API documentation.
